### PR TITLE
Fixing revision list with custom .gitconfig

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -111,7 +111,7 @@ class Git
     public function getRevisions()
     {
         $this->execute(
-            'git log --no-merges --date-order --reverse',
+            'git log --no-merges --date-order --reverse --format=medium',
             $output,
             $return
         );


### PR DESCRIPTION
If a user has a custom format setup in .gitconfig, it breaks revision listing.  Adding --format=medium should override it with the expected output.
