### PR TITLE
in checkout(): fixed missing space between "--quiet" & the revision

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -71,7 +71,7 @@ class Git
     public function checkout($revision)
     {
         $this->execute(
-            'git checkout --force --quiet' . $revision . ' 2>&1',
+            'git checkout --force --quiet ' . $revision . ' 2>&1',
             $output,
             $return
         );


### PR DESCRIPTION
The checkout() method is broken as there is no space between the --quiet option and the revision. This fixes it.
