### PR TITLE
New implementation of getCurrentBranch() to use "git rev-parse --abbrev-...

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -80,12 +80,8 @@ class Git
      */
     public function getCurrentBranch()
     {
-        $output = $this->execute('git status --porcelain --branch');
-
-        $tmp = explode(' ', $output[0]);
-        $tmp = explode('...', $tmp[1]);
-
-        return $tmp[0];
+        $output = $this->execute('git rev-parse --abbrev-ref HEAD');
+        return $output[0];
     }
 
     /**


### PR DESCRIPTION
...ref HEAD"

The implementation of getCurrentBranch() using 'git status --porcelain --branch' didn't work for me.  Running the command in the terminal produced:

    git status --porcelain --branch                                    
    ## task/solr
    M composer.json
    ?? gulpfile.js

The method was ignoring the first line and returned the first letter of the line 2, 'M'.

I have modified this to use 'git rev-parse --abbrev-ref HEAD' which returns a single string.

Also - my first Open Source contribution!