### PR TITLE
Set repositoryPath to protected

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -55,7 +55,7 @@ class Git
     /**
      * @var string
      */
-    private $repositoryPath;
+    protected $repositoryPath;
 
     /**
      * @param string $repositoryPath


### PR DESCRIPTION
Setting the repository path to protected will allow people that extend this class read and write the repositoryPath parameter.

This will allow one instance of the class to manage multiple instances of a repository by updating the repositoryPath variable prior to executing commands.