### PR TITLE
Convert array to string when passing to exception

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -149,7 +149,7 @@ class Git
         chdir($cwd);
 
         if ($returnValue !== 0) {
-            throw new RuntimeException($output);
+            throw new RuntimeException(implode("\r\n",$output));
         }
 
         return $output;


### PR DESCRIPTION
Without this, I get "Fatal error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]])"