### PR TITLE
FIX command return false string after git init

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -44,12 +44,11 @@ class Git
      */
     public function getCurrentBranch()
     {
-        $output = $this->execute('git status --porcelain --branch');
+        $output = $this->execute('git symbolic-ref HEAD');
 
-        $tmp = explode(' ', $output[0]);
-        $tmp = explode('...', $tmp[1]);
+        $tmp = explode('/', $output[0]);
 
-        return $tmp[0];
+        return $tmp[2];
     }
 
     /**


### PR DESCRIPTION
```public function getCurrentBranch()``` returning wrong string ```string(7) "Initial"``` in repositories when called after ```git init```

```bash
>git status --porcelain --branch
## Initial commit on master
```
vs
```bash
>git symbolic-ref HEAD
refs/heads/master
```
