### PR TITLE
Fix getCurrentBranch() to support branches with slashes

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -53,11 +53,9 @@ class Git
      */
     public function getCurrentBranch()
     {
-        $output = $this->execute('symbolic-ref HEAD');
+        $output = $this->execute('symbolic-ref --short HEAD');
 
-        $tmp = explode('/', $output[0]);
-
-        return $tmp[2];
+        return $output[0];
     }
 
     /**


### PR DESCRIPTION
Currently ``getCurrentBranch()`` does not return correct branch name if it has slashes (``/``) in it. 
For example if you are on ``feature/some-branch``, which is a common use case if you are using git-flow, it only returns ``feature``.