### PR TITLE
Avoid using git -C

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -126,7 +126,7 @@ class Git
      */
     protected function execute($command)
     {
-        $command = 'git -C ' . escapeshellarg($this->repositoryPath) . ' ' . $command;
+        $command = 'cd ' . escapeshellarg($this->repositoryPath) . '; git ' . $command;
         if (DIRECTORY_SEPARATOR == '/') {
             $command = 'LC_ALL=en_US.UTF-8 ' . $command;
         }


### PR DESCRIPTION
git -C has been added in Git 1.8.5, however some Linux distributions (e.g. Ubuntu Precise) and their packages still ship with older Git releases that don't support this option. I think it is safe to `cd` manually instead, it does the same thing.
