### PR TITLE
Update git status message

### DIFF
--- a/src/Git.php
+++ b/src/Git.php
@@ -117,7 +117,7 @@ class Git
     {
         $output = $this->execute('status');
 
-        return $output[count($output)-1] == 'nothing to commit, working directory clean';
+        return $output[count($output)-1] == 'nothing to commit, working tree clean';
     }
 
     /**


### PR DESCRIPTION
![screenshot 2016-08-17 03 56 03](https://cloud.githubusercontent.com/assets/88371/17723019/8c1fdc34-642e-11e6-931d-28177aca0790.png)

I'm not sure when this changed, but for Git 2.9.3 (latest version), the message to see if the working copy is clean uses the word "tree" instead of "directory". 

As such, `phploc --git-repository .` fails, as it thinks the working copy isn't clean.

For back-compat, you may want a more sophisticated solution to allow both "directory" and "tree".
